### PR TITLE
Fix installing chef-solo errors for python 3

### DIFF
--- a/littlechef/solo.py
+++ b/littlechef/solo.py
@@ -30,7 +30,7 @@ def install(version):
     """Install Chef using the omnibus installer"""
     url = "https://www.chef.io/chef/install.sh"
     with hide('stdout', 'running'):
-        local("""python -c "import urllib; print urllib.urlopen('{0}').read()"'
+        local("""python -c "import urllib.request; print(urllib.request.urlopen('{0}').read().decode('utf-8'))"'
               ' > /tmp/install.sh""".format(url))
         put('/tmp/install.sh', '/tmp/install.sh')
         print("Downloading and installing Chef {0}...".format(version))


### PR DESCRIPTION
Installing chef-solo should be python 3 compatible.

* `print()`
* `urllib.urlopen` -> `urllib.request.urlopen`
* convert download sh content from `bytes` to `unicode`, otherwise the sh file starts with `b'#sh...'`